### PR TITLE
Added os framework so it can be available to sync with KlarnaMobileSDK

### DIFF
--- a/ios/Classes/SwiftFlutterKlarnaInappSdk.swift
+++ b/ios/Classes/SwiftFlutterKlarnaInappSdk.swift
@@ -1,8 +1,12 @@
 import Flutter
+import os
 
 // MARK: - SwiftFlutterKlarnaInappSdk
 public class SwiftFlutterKlarnaInappSdk: NSObject, FlutterPlugin {
     public static func register(with registrar: FlutterPluginRegistrar) {
+        let osLog = OSLog(subsystem: "Flutter", category: "KlarnaInappSdk")
+        os_log("register event", log: osLog, type: .debug)
+
         let messenger = registrar.messenger()
         
         getMethodHandlerMap().forEach { (key, value) in


### PR DESCRIPTION
Fix: _IDE Build System When a target that contains Swift code adds a new dependency on a Swift system library, Xcode will not copy that runtime library into the app until the next full build. This will cause a runtime error such as “dyld: Library not loaded: @rpath/libswiftos.dylib”_
